### PR TITLE
Fix vignette path

### DIFF
--- a/vignettes/a01_introCreateCohort.Rmd
+++ b/vignettes/a01_introCreateCohort.Rmd
@@ -55,7 +55,8 @@ To create a cohort with a concept list from a .json file, use
 `codesFromConceptSet()` from CodelistGenerator package. Let's see an example:
 
 ```{r}
-conceptSet_json <- codesFromConceptSet(here::here("inst/Concept"), cdm)
+conceptSet_json <- codesFromConceptSet(
+  system.file("Concept", package = "DrugUtilisation"), cdm)
 conceptSet_json
 ```
 


### PR DESCRIPTION
This is a more robust way to specify the file, which should fix the failed vignette builds [here](https://cran.r-project.org/web/checks/check_results_DrugUtilisation.html).